### PR TITLE
Add Support for Compound Units

### DIFF
--- a/src/acceleration.hh
+++ b/src/acceleration.hh
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "velocity.hh"
+
+namespace lmc::units::acceleration
+{
+using meters_per_second_squared
+    = impl::cnt::unit_container<impl::def::definition_divide<
+        velocity::meters_per_second::definition,
+        time::seconds::definition>>;
+ADD_PREFIXES_TO_CONTAINER(meters_per_second_squared)
+
+using dimension = meters_per_second_squared::definition::dimension;
+
+template <impl::cnt::cpt::unit_container container>
+using is_acceleration_unit
+    = dimension::equals<typename container::definition::dimension>;
+
+template <impl::cnt::cpt::unit_container container>
+constexpr bool is_acceleration_unit_v = is_acceleration_unit<container>::value;
+
+using feet_per_second_squared
+    = impl::cnt::unit_container<impl::def::definition_divide<
+        length::feet::definition,
+        impl::def::definition_squared<time::seconds::definition>>>;
+
+using knots_per_second = impl::cnt::unit_container<impl::def::definition_divide<
+    velocity::knots::definition,
+    time::seconds::definition>>;
+
+} // namespace lmc::units::acceleration

--- a/src/capacitance.hh
+++ b/src/capacitance.hh
@@ -5,15 +5,12 @@
 
 namespace lmc::units::capacitance
 {
+using farads = impl::cnt::unit_container<impl::def::definition_divide<
+    charge::coulombs::definition,
+    voltage::volts::definition>>;
+ADD_PREFIXES_TO_CONTAINER(farads)
 
-using dimension = impl::dim::dimensional_vector<
-    impl::dim::length<0>,
-    impl::dim::mass<0>,
-    impl::dim::time<1>,
-    impl::dim::current<1>,
-    impl::dim::temperature<0>,
-    impl::dim::luminosity<0>,
-    impl::dim::substance<0>>;
+using dimension = farads::definition::dimension;
 
 template <impl::cnt::cpt::unit_container container>
 using is_capacitance_unit
@@ -21,9 +18,5 @@ using is_capacitance_unit
 
 template <impl::cnt::cpt::unit_container container>
 constexpr bool is_capacitance_unit_v = is_capacitance_unit<container>::value;
-
-using farads = impl::cnt::unit_container<impl::def::definition_divide<
-    charge::coulombs::definition,
-    voltage::volts::definition>>;
 
 } // namespace lmc::units::capacitance

--- a/src/capacitance.hh
+++ b/src/capacitance.hh
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "charge.hh"
+#include "voltage.hh"
+
+namespace lmc::units::capacitance
+{
+
+using dimension = impl::dim::dimensional_vector<
+    impl::dim::length<0>,
+    impl::dim::mass<0>,
+    impl::dim::time<1>,
+    impl::dim::current<1>,
+    impl::dim::temperature<0>,
+    impl::dim::luminosity<0>,
+    impl::dim::substance<0>>;
+
+template <impl::cnt::cpt::unit_container container>
+using is_capacitance_unit
+    = dimension::equals<typename container::definition::dimension>;
+
+template <impl::cnt::cpt::unit_container container>
+constexpr bool is_capacitance_unit_v = is_capacitance_unit<container>::value;
+
+using farads = impl::cnt::unit_container<impl::def::definition_divide<
+    charge::coulombs::definition,
+    voltage::volts::definition>>;
+
+} // namespace lmc::units::capacitance

--- a/src/catalytic_activity.hh
+++ b/src/catalytic_activity.hh
@@ -5,15 +5,12 @@
 
 namespace lmc::units::catalytic_activity
 {
+using katals = impl::cnt::unit_container<impl::def::definition_divide<
+    substance::moles::definition,
+    time::seconds::definition>>;
+ADD_PREFIXES_TO_CONTAINER(katals)
 
-using dimension = impl::dim::dimensional_vector<
-    impl::dim::length<0>,
-    impl::dim::mass<0>,
-    impl::dim::time<1>,
-    impl::dim::current<1>,
-    impl::dim::temperature<0>,
-    impl::dim::luminosity<0>,
-    impl::dim::substance<0>>;
+using dimension = katals::definition::dimension;
 
 template <impl::cnt::cpt::unit_container container>
 using is_catalytic_activity_unit
@@ -22,9 +19,5 @@ using is_catalytic_activity_unit
 template <impl::cnt::cpt::unit_container container>
 constexpr bool is_catalytic_activity_unit_v
     = is_catalytic_activity_unit<container>::value;
-
-using katals = impl::cnt::unit_container<impl::def::definition_divide<
-    substance::moles::definition,
-    time::seconds::definition>>;
 
 } // namespace lmc::units::catalytic_activity

--- a/src/catalytic_activity.hh
+++ b/src/catalytic_activity.hh
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "substance.hh"
+#include "time.hh"
+
+namespace lmc::units::catalytic_activity
+{
+
+using dimension = impl::dim::dimensional_vector<
+    impl::dim::length<0>,
+    impl::dim::mass<0>,
+    impl::dim::time<1>,
+    impl::dim::current<1>,
+    impl::dim::temperature<0>,
+    impl::dim::luminosity<0>,
+    impl::dim::substance<0>>;
+
+template <impl::cnt::cpt::unit_container container>
+using is_catalytic_activity_unit
+    = dimension::equals<typename container::definition::dimension>;
+
+template <impl::cnt::cpt::unit_container container>
+constexpr bool is_catalytic_activity_unit_v
+    = is_catalytic_activity_unit<container>::value;
+
+using katals = impl::cnt::unit_container<impl::def::definition_divide<
+    substance::moles::definition,
+    time::seconds::definition>>;
+
+} // namespace lmc::units::catalytic_activity

--- a/src/charge.hh
+++ b/src/charge.hh
@@ -5,15 +5,12 @@
 
 namespace lmc::units::charge
 {
+using coulombs = impl::cnt::unit_container<impl::def::definition_multiply<
+    current::amperes::definition,
+    time::seconds::definition>>;
+ADD_PREFIXES_TO_CONTAINER(coulombs)
 
-using dimension = impl::dim::dimensional_vector<
-    impl::dim::length<0>,
-    impl::dim::mass<0>,
-    impl::dim::time<1>,
-    impl::dim::current<1>,
-    impl::dim::temperature<0>,
-    impl::dim::luminosity<0>,
-    impl::dim::substance<0>>;
+using dimension = coulombs::definition::dimension;
 
 template <impl::cnt::cpt::unit_container container>
 using is_charge_unit
@@ -21,9 +18,5 @@ using is_charge_unit
 
 template <impl::cnt::cpt::unit_container container>
 constexpr bool is_charge_unit_v = is_charge_unit<container>::value;
-
-using coulombs = impl::cnt::unit_container<impl::def::definition_multiply<
-    current::amperes::definition,
-    time::seconds::definition>>;
 
 } // namespace lmc::units::charge

--- a/src/charge.hh
+++ b/src/charge.hh
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "current.hh"
+#include "time.hh"
+
+namespace lmc::units::charge
+{
+
+using dimension = impl::dim::dimensional_vector<
+    impl::dim::length<0>,
+    impl::dim::mass<0>,
+    impl::dim::time<1>,
+    impl::dim::current<1>,
+    impl::dim::temperature<0>,
+    impl::dim::luminosity<0>,
+    impl::dim::substance<0>>;
+
+template <impl::cnt::cpt::unit_container container>
+using is_charge_unit
+    = dimension::equals<typename container::definition::dimension>;
+
+template <impl::cnt::cpt::unit_container container>
+constexpr bool is_charge_unit_v = is_charge_unit<container>::value;
+
+using coulombs = impl::cnt::unit_container<impl::def::definition_multiply<
+    current::amperes::definition,
+    time::seconds::definition>>;
+
+} // namespace lmc::units::charge

--- a/src/conductance.hh
+++ b/src/conductance.hh
@@ -4,15 +4,11 @@
 
 namespace lmc::units::conductance
 {
+using siemens = impl::cnt::unit_container<
+    impl::def::definition_reciprocate<resistance::ohms::definition>>;
+ADD_PREFIXES_TO_CONTAINER(siemens)
 
-using dimension = impl::dim::dimensional_vector<
-    impl::dim::length<0>,
-    impl::dim::mass<0>,
-    impl::dim::time<1>,
-    impl::dim::current<1>,
-    impl::dim::temperature<0>,
-    impl::dim::luminosity<0>,
-    impl::dim::substance<0>>;
+using dimension = siemens::definition::dimension;
 
 template <impl::cnt::cpt::unit_container container>
 using is_conductance_unit
@@ -20,8 +16,5 @@ using is_conductance_unit
 
 template <impl::cnt::cpt::unit_container container>
 constexpr bool is_conductance_unit_v = is_conductance_unit<container>::value;
-
-using siemens                        = impl::cnt::unit_container<
-    impl::def::definition_reciprocate<resistance::ohms::definition>>;
 
 } // namespace lmc::units::conductance

--- a/src/conductance.hh
+++ b/src/conductance.hh
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "resistance.hh"
+
+namespace lmc::units::conductance
+{
+
+using dimension = impl::dim::dimensional_vector<
+    impl::dim::length<0>,
+    impl::dim::mass<0>,
+    impl::dim::time<1>,
+    impl::dim::current<1>,
+    impl::dim::temperature<0>,
+    impl::dim::luminosity<0>,
+    impl::dim::substance<0>>;
+
+template <impl::cnt::cpt::unit_container container>
+using is_conductance_unit
+    = dimension::equals<typename container::definition::dimension>;
+
+template <impl::cnt::cpt::unit_container container>
+constexpr bool is_conductance_unit_v = is_conductance_unit<container>::value;
+
+using siemens                        = impl::cnt::unit_container<
+    impl::def::definition_reciprocate<resistance::ohms::definition>>;
+
+} // namespace lmc::units::conductance

--- a/src/dose.hh
+++ b/src/dose.hh
@@ -5,27 +5,12 @@
 namespace lmc::units::dose
 {
 
-using dimension = impl::dim::dimensional_vector<
-    impl::dim::length<0>,
-    impl::dim::mass<0>,
-    impl::dim::time<1>,
-    impl::dim::current<1>,
-    impl::dim::temperature<0>,
-    impl::dim::luminosity<0>,
-    impl::dim::substance<0>>;
-
-template <impl::cnt::cpt::unit_container container>
-using is_dose_unit
-    = dimension::equals<typename container::definition::dimension>;
-
-template <impl::cnt::cpt::unit_container container>
-constexpr bool is_dose_unit_v = is_dose_unit<container>::value;
-
 namespace absorbed
 {
 using grays = impl::cnt::unit_container<impl::def::definition_divide<
     impl::def::definition_squared<energy::joules::definition>,
     impl::def::definition_squared<mass::kilograms::definition>>>;
+ADD_PREFIXES_TO_CONTAINER(grays)
 
 } // namespace absorbed
 
@@ -34,7 +19,20 @@ namespace equivalent
 using sieverts = impl::cnt::unit_container<impl::def::definition_divide<
     impl::def::definition_squared<energy::joules::definition>,
     impl::def::definition_squared<mass::kilograms::definition>>>;
+ADD_PREFIXES_TO_CONTAINER(sieverts)
 
 } // namespace equivalent
+
+static_assert(absorbed::grays::definition::dimension::equals_v<
+              equivalent::sieverts::definition::dimension>);
+
+using dimension = absorbed::grays::definition::dimension;
+
+template <impl::cnt::cpt::unit_container container>
+using is_dose_unit
+    = dimension::equals<typename container::definition::dimension>;
+
+template <impl::cnt::cpt::unit_container container>
+constexpr bool is_dose_unit_v = is_dose_unit<container>::value;
 
 } // namespace lmc::units::dose

--- a/src/dose.hh
+++ b/src/dose.hh
@@ -8,8 +8,8 @@ namespace lmc::units::dose
 namespace absorbed
 {
 using grays = impl::cnt::unit_container<impl::def::definition_divide<
-    impl::def::definition_squared<energy::joules::definition>,
-    impl::def::definition_squared<mass::kilograms::definition>>>;
+    energy::joules::definition,
+    mass::kilograms::definition>>;
 ADD_PREFIXES_TO_CONTAINER(grays)
 
 } // namespace absorbed
@@ -17,8 +17,8 @@ ADD_PREFIXES_TO_CONTAINER(grays)
 namespace equivalent
 {
 using sieverts = impl::cnt::unit_container<impl::def::definition_divide<
-    impl::def::definition_squared<energy::joules::definition>,
-    impl::def::definition_squared<mass::kilograms::definition>>>;
+    energy::joules::definition,
+    mass::kilograms::definition>>;
 ADD_PREFIXES_TO_CONTAINER(sieverts)
 
 } // namespace equivalent

--- a/src/dose.hh
+++ b/src/dose.hh
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "energy.hh"
+
+namespace lmc::units::dose
+{
+
+using dimension = impl::dim::dimensional_vector<
+    impl::dim::length<0>,
+    impl::dim::mass<0>,
+    impl::dim::time<1>,
+    impl::dim::current<1>,
+    impl::dim::temperature<0>,
+    impl::dim::luminosity<0>,
+    impl::dim::substance<0>>;
+
+template <impl::cnt::cpt::unit_container container>
+using is_dose_unit
+    = dimension::equals<typename container::definition::dimension>;
+
+template <impl::cnt::cpt::unit_container container>
+constexpr bool is_dose_unit_v = is_dose_unit<container>::value;
+
+namespace absorbed
+{
+using grays = impl::cnt::unit_container<impl::def::definition_divide<
+    impl::def::definition_squared<energy::joules::definition>,
+    impl::def::definition_squared<mass::kilograms::definition>>>;
+
+} // namespace absorbed
+
+namespace equivalent
+{
+using sieverts = impl::cnt::unit_container<impl::def::definition_divide<
+    impl::def::definition_squared<energy::joules::definition>,
+    impl::def::definition_squared<mass::kilograms::definition>>>;
+
+} // namespace equivalent
+
+} // namespace lmc::units::dose

--- a/src/energy.hh
+++ b/src/energy.hh
@@ -4,15 +4,12 @@
 
 namespace lmc::units::energy
 {
+using joules = impl::cnt::unit_container<impl::def::definition_multiply<
+    force::newtons::definition,
+    length::meters::definition>>;
+ADD_PREFIXES_TO_CONTAINER(joules)
 
-using dimension = impl::dim::dimensional_vector<
-    impl::dim::length<1>,
-    impl::dim::mass<-1>,
-    impl::dim::time<-2>,
-    impl::dim::current<0>,
-    impl::dim::temperature<0>,
-    impl::dim::luminosity<0>,
-    impl::dim::substance<0>>;
+using dimension = joules::definition::dimension;
 
 template <impl::cnt::cpt::unit_container container>
 using is_energy_unit
@@ -21,13 +18,7 @@ using is_energy_unit
 template <impl::cnt::cpt::unit_container container>
 constexpr bool is_energy_unit_v = is_energy_unit<container>::value;
 
-using joules = impl::cnt::unit_container<impl::def::definition_multiply<
-    force::newtons::definition,
-    length::meters::definition>>;
-
-ADD_PREFIXES_TO_CONTAINER(joules)
-
-using foot_pound_force = impl::abbr::
+using foot_pound_force          = impl::abbr::
     derive<std::ratio_add<std::ratio<1>, std::ratio<1779, 5000>>, joules>;
 
 using horsepower_hour = impl::abbr::

--- a/src/energy.hh
+++ b/src/energy.hh
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "force.hh"
+
+namespace lmc::units::energy
+{
+
+using dimension = impl::dim::dimensional_vector<
+    impl::dim::length<1>,
+    impl::dim::mass<-1>,
+    impl::dim::time<-2>,
+    impl::dim::current<0>,
+    impl::dim::temperature<0>,
+    impl::dim::luminosity<0>,
+    impl::dim::substance<0>>;
+
+template <impl::cnt::cpt::unit_container container>
+using is_energy_unit
+    = dimension::equals<typename container::definition::dimension>;
+
+template <impl::cnt::cpt::unit_container container>
+constexpr bool is_energy_unit_v = is_energy_unit<container>::value;
+
+using joules = impl::cnt::unit_container<impl::def::definition_multiply<
+    force::newtons::definition,
+    length::meters::definition>>;
+
+ADD_PREFIXES_TO_CONTAINER(joules)
+
+using foot_pound_force = impl::abbr::
+    derive<std::ratio_add<std::ratio<1>, std::ratio<1779, 5000>>, joules>;
+
+using horsepower_hour = impl::abbr::
+    derive<std::ratio_add<std::ratio<2>, std::ratio<1369, 2000>>, megajoules>;
+
+using kilowatt_hour = impl::abbr::derive<std::ratio<36, 10>, megajoules>;
+using us_therms     = impl::abbr::derive<std::ratio<10548, 100>, megajoules>;
+
+using calories_th   = impl::abbr::derive<std::ratio<4184, 1000>, joules>;
+using calories_4    = impl::abbr::derive<std::ratio<4204, 1000>, joules>;
+using calories_15   = impl::abbr::derive<std::ratio<41855, 10000>, joules>;
+using calories_20   = impl::abbr::derive<std::ratio<4182, 1000>, joules>;
+using calories_mean = impl::abbr::derive<std::ratio<4190, 1000>, joules>;
+using calories_it   = impl::abbr::derive<std::ratio<41868, 10000>, joules>;
+
+using electronvolts
+    = impl::abbr::derive<std::ratio<160218, 1000000>, attojoules>;
+
+using ton_of_tnt = impl::abbr::derive<std::ratio<4184>, joules>;
+
+} // namespace lmc::units::energy

--- a/src/force.hh
+++ b/src/force.hh
@@ -3,19 +3,17 @@
 #include "length.hh"
 #include "mass.hh"
 #include "time.hh"
-#include "unit_container.hh"
 
 namespace lmc::units::force
 {
+using newtons = impl::cnt::unit_container<impl::def::definition_divide<
+    impl::def::definition_multiply<
+        mass::kilograms::definition,
+        length::meters::definition>,
+    impl::def::definition_squared<time::seconds::definition>>>;
+ADD_PREFIXES_TO_CONTAINER(newtons)
 
-using dimension = impl::dim::dimensional_vector<
-    impl::dim::length<1>,
-    impl::dim::mass<1>,
-    impl::dim::time<-2>,
-    impl::dim::current<0>,
-    impl::dim::temperature<0>,
-    impl::dim::luminosity<0>,
-    impl::dim::substance<0>>;
+using dimension = newtons::definition::dimension;
 
 template <impl::cnt::cpt::unit_container container>
 using is_force_unit
@@ -24,13 +22,7 @@ using is_force_unit
 template <impl::cnt::cpt::unit_container container>
 constexpr bool is_force_unit_v = is_force_unit<container>::value;
 
-using newtons  = impl::cnt::unit_container<impl::def::definition_divide<
-    impl::def::definition_multiply<
-        mass::kilograms::definition,
-        length::meters::definition>,
-    impl::def::definition_squared<time::seconds::definition>>>;
-
-using kilopond = impl::abbr::
+using kilopond                 = impl::abbr::
     derive<std::ratio_add<std::ratio<9>, std::ratio<16133, 20000>>, newtons>;
 
 using pounds = impl::abbr::

--- a/src/force.hh
+++ b/src/force.hh
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "length.hh"
+#include "mass.hh"
+#include "time.hh"
+#include "unit_container.hh"
+
+namespace lmc::units::force
+{
+
+using dimension = impl::dim::dimensional_vector<
+    impl::dim::length<1>,
+    impl::dim::mass<1>,
+    impl::dim::time<-2>,
+    impl::dim::current<0>,
+    impl::dim::temperature<0>,
+    impl::dim::luminosity<0>,
+    impl::dim::substance<0>>;
+
+template <impl::cnt::cpt::unit_container container>
+using is_force_unit
+    = dimension::equals<typename container::definition::dimension>;
+
+template <impl::cnt::cpt::unit_container container>
+constexpr bool is_force_unit_v = is_force_unit<container>::value;
+
+using newtons  = impl::cnt::unit_container<impl::def::definition_divide<
+    impl::def::definition_multiply<
+        mass::kilograms::definition,
+        length::meters::definition>,
+    impl::def::definition_squared<time::seconds::definition>>>;
+
+using kilopond = impl::abbr::
+    derive<std::ratio_add<std::ratio<9>, std::ratio<16133, 20000>>, newtons>;
+
+using pounds = impl::abbr::
+    derive<std::ratio_add<std::ratio<4>, std::ratio<224111, 500000>>, newtons>;
+
+using poundal
+    = impl::abbr::derive<std::ratio<17281869297, 125000000000>, newtons>;
+
+using dynes = impl::abbr::derive<std::ratio<1, 100000>, newtons>;
+
+} // namespace lmc::units::force
+

--- a/src/frequency.hh
+++ b/src/frequency.hh
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "time.hh"
+
+namespace lmc::units::frequency
+{
+
+using dimension = impl::dim::dimensional_vector<
+    impl::dim::length<0>,
+    impl::dim::mass<0>,
+    impl::dim::time<-1>,
+    impl::dim::current<0>,
+    impl::dim::temperature<0>,
+    impl::dim::luminosity<0>,
+    impl::dim::substance<0>>;
+
+template <impl::cnt::cpt::unit_container container>
+using is_frequency_unit
+    = dimension::equals<typename container::definition::dimension>;
+
+template <impl::cnt::cpt::unit_container container>
+constexpr bool is_frequency_unit_v = is_frequency_unit<container>::value;
+
+using hertz                        = impl::cnt::unit_container<
+    impl::def::definition_reciprocate<time::seconds::definition>>;
+
+} // namespace lmc::units::frequency
+

--- a/src/frequency.hh
+++ b/src/frequency.hh
@@ -4,15 +4,11 @@
 
 namespace lmc::units::frequency
 {
+using hertz = impl::cnt::unit_container<
+    impl::def::definition_reciprocate<time::seconds::definition>>;
+ADD_PREFIXES_TO_CONTAINER(hertz)
 
-using dimension = impl::dim::dimensional_vector<
-    impl::dim::length<0>,
-    impl::dim::mass<0>,
-    impl::dim::time<-1>,
-    impl::dim::current<0>,
-    impl::dim::temperature<0>,
-    impl::dim::luminosity<0>,
-    impl::dim::substance<0>>;
+using dimension = hertz::definition::dimension;
 
 template <impl::cnt::cpt::unit_container container>
 using is_frequency_unit
@@ -20,9 +16,6 @@ using is_frequency_unit
 
 template <impl::cnt::cpt::unit_container container>
 constexpr bool is_frequency_unit_v = is_frequency_unit<container>::value;
-
-using hertz                        = impl::cnt::unit_container<
-    impl::def::definition_reciprocate<time::seconds::definition>>;
 
 } // namespace lmc::units::frequency
 

--- a/src/inductance.hh
+++ b/src/inductance.hh
@@ -1,19 +1,15 @@
 #pragma once
 
-#include "current.hh"
 #include "magnetic_flux.hh"
 
 namespace lmc::units::inductance
 {
+using henrys = impl::cnt::unit_container<impl::def::definition_divide<
+    magnetic_flux::webers::definition,
+    current::amperes::definition>>;
+ADD_PREFIXES_TO_CONTAINER(henrys)
 
-using dimension = impl::dim::dimensional_vector<
-    impl::dim::length<0>,
-    impl::dim::mass<0>,
-    impl::dim::time<1>,
-    impl::dim::current<1>,
-    impl::dim::temperature<0>,
-    impl::dim::luminosity<0>,
-    impl::dim::substance<0>>;
+using dimension = henrys::definition::dimension;
 
 template <impl::cnt::cpt::unit_container container>
 using is_inductance_unit
@@ -21,9 +17,5 @@ using is_inductance_unit
 
 template <impl::cnt::cpt::unit_container container>
 constexpr bool is_inductance_unit_v = is_inductance_unit<container>::value;
-
-using henrys = impl::cnt::unit_container<impl::def::definition_divide<
-    magnetic_flux::webers::definition,
-    current::amperes::definition>>;
 
 } // namespace lmc::units::inductance

--- a/src/inductance.hh
+++ b/src/inductance.hh
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "current.hh"
+#include "magnetic_flux.hh"
+
+namespace lmc::units::inductance
+{
+
+using dimension = impl::dim::dimensional_vector<
+    impl::dim::length<0>,
+    impl::dim::mass<0>,
+    impl::dim::time<1>,
+    impl::dim::current<1>,
+    impl::dim::temperature<0>,
+    impl::dim::luminosity<0>,
+    impl::dim::substance<0>>;
+
+template <impl::cnt::cpt::unit_container container>
+using is_inductance_unit
+    = dimension::equals<typename container::definition::dimension>;
+
+template <impl::cnt::cpt::unit_container container>
+constexpr bool is_inductance_unit_v = is_inductance_unit<container>::value;
+
+using henrys = impl::cnt::unit_container<impl::def::definition_divide<
+    magnetic_flux::webers::definition,
+    current::amperes::definition>>;
+
+} // namespace lmc::units::inductance

--- a/src/magnetic_flux.hh
+++ b/src/magnetic_flux.hh
@@ -5,15 +5,12 @@
 
 namespace lmc::units::magnetic_flux
 {
+using webers = impl::cnt::unit_container<impl::def::definition_multiply<
+    voltage::volts::definition,
+    time::seconds::definition>>;
+ADD_PREFIXES_TO_CONTAINER(webers)
 
-using dimension = impl::dim::dimensional_vector<
-    impl::dim::length<0>,
-    impl::dim::mass<0>,
-    impl::dim::time<1>,
-    impl::dim::current<1>,
-    impl::dim::temperature<0>,
-    impl::dim::luminosity<0>,
-    impl::dim::substance<0>>;
+using dimension = webers::definition::dimension;
 
 template <impl::cnt::cpt::unit_container container>
 using is_magnetic_flux_unit
@@ -22,9 +19,5 @@ using is_magnetic_flux_unit
 template <impl::cnt::cpt::unit_container container>
 constexpr bool is_magnetic_flux_unit_v
     = is_magnetic_flux_unit<container>::value;
-
-using webers = impl::cnt::unit_container<impl::def::definition_multiply<
-    voltage::volts::definition,
-    time::seconds::definition>>;
 
 } // namespace lmc::units::magnetic_flux

--- a/src/magnetic_flux.hh
+++ b/src/magnetic_flux.hh
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "time.hh"
+#include "voltage.hh"
+
+namespace lmc::units::magnetic_flux
+{
+
+using dimension = impl::dim::dimensional_vector<
+    impl::dim::length<0>,
+    impl::dim::mass<0>,
+    impl::dim::time<1>,
+    impl::dim::current<1>,
+    impl::dim::temperature<0>,
+    impl::dim::luminosity<0>,
+    impl::dim::substance<0>>;
+
+template <impl::cnt::cpt::unit_container container>
+using is_magnetic_flux_unit
+    = dimension::equals<typename container::definition::dimension>;
+
+template <impl::cnt::cpt::unit_container container>
+constexpr bool is_magnetic_flux_unit_v
+    = is_magnetic_flux_unit<container>::value;
+
+using webers = impl::cnt::unit_container<impl::def::definition_multiply<
+    voltage::volts::definition,
+    time::seconds::definition>>;
+
+} // namespace lmc::units::magnetic_flux

--- a/src/magnetic_flux_density.hh
+++ b/src/magnetic_flux_density.hh
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "magnetic_flux.hh"
+#include "unit_definition.hh"
+
+namespace lmc::units::magnetic_flux_density
+{
+
+using dimension = impl::dim::dimensional_vector<
+    impl::dim::length<0>,
+    impl::dim::mass<0>,
+    impl::dim::time<1>,
+    impl::dim::current<1>,
+    impl::dim::temperature<0>,
+    impl::dim::luminosity<0>,
+    impl::dim::substance<0>>;
+
+template <impl::cnt::cpt::unit_container container>
+using is_magnetic_flux_density_unit
+    = dimension::equals<typename container::definition::dimension>;
+
+template <impl::cnt::cpt::unit_container container>
+constexpr bool is_magnetic_flux_density_unit_v
+    = is_magnetic_flux_density_unit<container>::value;
+
+using teslas = impl::cnt::unit_container<impl::def::definition_divide<
+    magnetic_flux::webers::definition,
+    impl::def::definition_squared<length::meters::definition>>>;
+
+} // namespace lmc::units::magnetic_flux_density

--- a/src/magnetic_flux_density.hh
+++ b/src/magnetic_flux_density.hh
@@ -1,19 +1,15 @@
 #pragma once
 
 #include "magnetic_flux.hh"
-#include "unit_definition.hh"
 
 namespace lmc::units::magnetic_flux_density
 {
+using teslas = impl::cnt::unit_container<impl::def::definition_divide<
+    magnetic_flux::webers::definition,
+    impl::def::definition_squared<length::meters::definition>>>;
+ADD_PREFIXES_TO_CONTAINER(teslas)
 
-using dimension = impl::dim::dimensional_vector<
-    impl::dim::length<0>,
-    impl::dim::mass<0>,
-    impl::dim::time<1>,
-    impl::dim::current<1>,
-    impl::dim::temperature<0>,
-    impl::dim::luminosity<0>,
-    impl::dim::substance<0>>;
+using dimension = teslas::definition::dimension;
 
 template <impl::cnt::cpt::unit_container container>
 using is_magnetic_flux_density_unit
@@ -22,9 +18,5 @@ using is_magnetic_flux_density_unit
 template <impl::cnt::cpt::unit_container container>
 constexpr bool is_magnetic_flux_density_unit_v
     = is_magnetic_flux_density_unit<container>::value;
-
-using teslas = impl::cnt::unit_container<impl::def::definition_divide<
-    magnetic_flux::webers::definition,
-    impl::def::definition_squared<length::meters::definition>>>;
 
 } // namespace lmc::units::magnetic_flux_density

--- a/src/power.hh
+++ b/src/power.hh
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "energy.hh"
+
+namespace lmc::units::power
+{
+
+using dimension = impl::dim::dimensional_vector<
+    impl::dim::length<1>,
+    impl::dim::mass<-1>,
+    impl::dim::time<-2>,
+    impl::dim::current<0>,
+    impl::dim::temperature<0>,
+    impl::dim::luminosity<0>,
+    impl::dim::substance<0>>;
+
+template <impl::cnt::cpt::unit_container container>
+using is_power_unit
+    = dimension::equals<typename container::definition::dimension>;
+
+template <impl::cnt::cpt::unit_container container>
+constexpr bool is_power_unit_v = is_power_unit<container>::value;
+
+using watt                     = impl::def::
+    definition_divide<energy::joules::definition, time::seconds::definition>;
+
+} // namespace lmc::units::power

--- a/src/power.hh
+++ b/src/power.hh
@@ -4,15 +4,12 @@
 
 namespace lmc::units::power
 {
+using watts = impl::cnt::unit_container<impl::def::definition_divide<
+    energy::joules::definition,
+    time::seconds::definition>>;
+ADD_PREFIXES_TO_CONTAINER(watts)
 
-using dimension = impl::dim::dimensional_vector<
-    impl::dim::length<1>,
-    impl::dim::mass<-1>,
-    impl::dim::time<-2>,
-    impl::dim::current<0>,
-    impl::dim::temperature<0>,
-    impl::dim::luminosity<0>,
-    impl::dim::substance<0>>;
+using dimension = watts::definition::dimension;
 
 template <impl::cnt::cpt::unit_container container>
 using is_power_unit
@@ -20,10 +17,6 @@ using is_power_unit
 
 template <impl::cnt::cpt::unit_container container>
 constexpr bool is_power_unit_v = is_power_unit<container>::value;
-
-using watts      = impl::cnt::unit_container<impl::def::definition_divide<
-    energy::joules::definition,
-    time::seconds::definition>>;
 
 using horsepower = impl::abbr::derive<std::ratio<7457, 10>, watts>;
 

--- a/src/power.hh
+++ b/src/power.hh
@@ -21,7 +21,10 @@ using is_power_unit
 template <impl::cnt::cpt::unit_container container>
 constexpr bool is_power_unit_v = is_power_unit<container>::value;
 
-using watt                     = impl::def::
-    definition_divide<energy::joules::definition, time::seconds::definition>;
+using watts      = impl::cnt::unit_container<impl::def::definition_divide<
+    energy::joules::definition,
+    time::seconds::definition>>;
+
+using horsepower = impl::abbr::derive<std::ratio<7457, 10>, watts>;
 
 } // namespace lmc::units::power

--- a/src/pressure.hh
+++ b/src/pressure.hh
@@ -1,21 +1,15 @@
 #pragma once
 
 #include "force.hh"
-#include "length.hh"
-#include "unit_container.hh"
-#include "unit_definition.hh"
 
 namespace lmc::units::pressure
 {
+using pascals = impl::cnt::unit_container<impl::def::definition_divide<
+    force::newtons::definition,
+    impl::def::definition_squared<length::meters::definition>>>;
+ADD_PREFIXES_TO_CONTAINER(pascals)
 
-using dimension = impl::dim::dimensional_vector<
-    impl::dim::length<1>,
-    impl::dim::mass<-1>,
-    impl::dim::time<-2>,
-    impl::dim::current<0>,
-    impl::dim::temperature<0>,
-    impl::dim::luminosity<0>,
-    impl::dim::substance<0>>;
+using dimension = pascals::definition::dimension;
 
 template <impl::cnt::cpt::unit_container container>
 using is_pressure_unit
@@ -24,11 +18,7 @@ using is_pressure_unit
 template <impl::cnt::cpt::unit_container container>
 constexpr bool is_pressure_unit_v = is_pressure_unit<container>::value;
 
-using pascals = impl::cnt::unit_container<impl::def::definition_divide<
-    force::newtons::definition,
-    impl::def::definition_squared<length::meters::definition>>>;
-
-using bars    = impl::abbr::derive<std::ratio<100000>, pascals>;
+using bars = impl::abbr::derive<std::ratio<100000>, pascals>;
 
 using technical_atmospheres
     = impl::abbr::derive<std::ratio<980665, 10>, pascals>;

--- a/src/pressure.hh
+++ b/src/pressure.hh
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "force.hh"
+#include "length.hh"
+#include "unit_container.hh"
+#include "unit_definition.hh"
+
+namespace lmc::units::pressure
+{
+
+using dimension = impl::dim::dimensional_vector<
+    impl::dim::length<1>,
+    impl::dim::mass<-1>,
+    impl::dim::time<-2>,
+    impl::dim::current<0>,
+    impl::dim::temperature<0>,
+    impl::dim::luminosity<0>,
+    impl::dim::substance<0>>;
+
+template <impl::cnt::cpt::unit_container container>
+using is_pressure_unit
+    = dimension::equals<typename container::definition::dimension>;
+
+template <impl::cnt::cpt::unit_container container>
+constexpr bool is_pressure_unit_v = is_pressure_unit<container>::value;
+
+using pascals = impl::cnt::unit_container<impl::def::definition_divide<
+    force::newtons::definition,
+    impl::def::definition_squared<length::meters::definition>>>;
+
+using bars    = impl::abbr::derive<std::ratio<100000>, pascals>;
+
+using technical_atmospheres
+    = impl::abbr::derive<std::ratio<980665, 10>, pascals>;
+
+using atmospheres = impl::abbr::derive<std::ratio<101325>, pascals>;
+
+using torrs       = impl::abbr::derive<std::ratio<1, 760>, atmospheres>;
+
+using pounds_per_square_inch = impl::abbr::derive<
+    std::ratio_add<std::ratio<6894>, std::ratio<47330823, 62500000>>,
+    pascals>;
+
+} // namespace lmc::units::pressure
+

--- a/src/resistance.hh
+++ b/src/resistance.hh
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "voltage.hh"
+
+namespace lmc::units::resistance
+{
+
+using dimension = impl::dim::dimensional_vector<
+    impl::dim::length<0>,
+    impl::dim::mass<0>,
+    impl::dim::time<1>,
+    impl::dim::current<1>,
+    impl::dim::temperature<0>,
+    impl::dim::luminosity<0>,
+    impl::dim::substance<0>>;
+
+template <impl::cnt::cpt::unit_container container>
+using is_resistance_unit
+    = dimension::equals<typename container::definition::dimension>;
+
+template <impl::cnt::cpt::unit_container container>
+constexpr bool is_resistance_unit_v = is_resistance_unit<container>::value;
+
+using ohms = impl::cnt::unit_container<impl::def::definition_divide<
+    voltage::volts::definition,
+    current::amperes::definition>>;
+
+} // namespace lmc::units::resistance

--- a/src/resistance.hh
+++ b/src/resistance.hh
@@ -5,14 +5,12 @@
 namespace lmc::units::resistance
 {
 
-using dimension = impl::dim::dimensional_vector<
-    impl::dim::length<0>,
-    impl::dim::mass<0>,
-    impl::dim::time<1>,
-    impl::dim::current<1>,
-    impl::dim::temperature<0>,
-    impl::dim::luminosity<0>,
-    impl::dim::substance<0>>;
+using ohms = impl::cnt::unit_container<impl::def::definition_divide<
+    voltage::volts::definition,
+    current::amperes::definition>>;
+ADD_PREFIXES_TO_CONTAINER(ohms)
+
+using dimension = ohms::definition::dimension;
 
 template <impl::cnt::cpt::unit_container container>
 using is_resistance_unit
@@ -20,9 +18,5 @@ using is_resistance_unit
 
 template <impl::cnt::cpt::unit_container container>
 constexpr bool is_resistance_unit_v = is_resistance_unit<container>::value;
-
-using ohms = impl::cnt::unit_container<impl::def::definition_divide<
-    voltage::volts::definition,
-    current::amperes::definition>>;
 
 } // namespace lmc::units::resistance

--- a/src/unit_container.hh
+++ b/src/unit_container.hh
@@ -90,6 +90,36 @@ public:
         };
     }
 
+    template <cpt::unit_container other_unit_container>
+    [[nodiscard]]
+    constexpr auto
+    operator* (other_unit_container other) const noexcept
+        -> unit_container<def::definition_multiply<
+            definition,
+            typename other_unit_container::definition>>
+    {
+        using type = unit_container<def::definition_multiply<
+            definition,
+            typename other_unit_container::definition>>;
+
+        return type { _measurement * other.get_measurement() };
+    }
+
+    template <cpt::unit_container other_unit_container>
+    [[nodiscard]]
+    constexpr auto
+    operator/ (other_unit_container other) const noexcept
+        -> unit_container<def::definition_divide<
+            definition,
+            typename other_unit_container::definition>>
+    {
+        using type = unit_container<def::definition_divide<
+            definition,
+            typename other_unit_container::definition>>;
+
+        return type { _measurement / other.get_measurement() };
+    }
+
     [[nodiscard]]
     constexpr auto
     get_measurement() const noexcept -> long double

--- a/src/unit_definition.hh
+++ b/src/unit_definition.hh
@@ -107,9 +107,8 @@ template <cpt::unit_conversion t>
 constexpr auto
 apply_conversion(long double const measurement) noexcept -> long double
 {
-    return (
-        t::ratio::value * ((measurement * t::prefix::value) + t::delta::value)
-    );
+    return { t::ratio::value
+             * ((measurement * t::prefix::value) + t::delta::value) };
 }
 
 template <cpt::unit_definition t, cmp::cpt::unit_prefix p>
@@ -135,9 +134,19 @@ using definition_multiply = unit_definition<
 
 template <cpt::unit_definition a, cpt::unit_definition b>
 using definition_divide = unit_definition<
-    typename a::dimension::template add<typename b::dimension>,
+    typename a::dimension::template subtract<typename b::dimension>,
     convert_unit_prefix<a, b>,
     convert_unit_ratio<a, b>,
     convert_unit_delta<a, b>>;
+
+template <cpt::unit_definition t>
+using definition_squared = definition_multiply<t, t>;
+
+template <cpt::unit_definition t>
+using definition_reciprocate = unit_definition<
+    typename t::dimension::template multiply<std::ratio<-1>>,
+    typename t::prefix,
+    typename t::ratio,
+    typename t::delta>;
 
 } // namespace lmc::units::impl::def

--- a/src/unit_definition.hh
+++ b/src/unit_definition.hh
@@ -126,4 +126,18 @@ using definition_with_derived_ratio = unit_definition<
     derive_unit_ratio<r, t>,
     typename t::delta>;
 
+template <cpt::unit_definition a, cpt::unit_definition b>
+using definition_multiply = unit_definition<
+    typename a::dimension::template add<typename b::dimension>,
+    convert_unit_prefix<a, b>,
+    convert_unit_ratio<a, b>,
+    convert_unit_delta<a, b>>;
+
+template <cpt::unit_definition a, cpt::unit_definition b>
+using definition_divide = unit_definition<
+    typename a::dimension::template add<typename b::dimension>,
+    convert_unit_prefix<a, b>,
+    convert_unit_ratio<a, b>,
+    convert_unit_delta<a, b>>;
+
 } // namespace lmc::units::impl::def

--- a/src/velocity.hh
+++ b/src/velocity.hh
@@ -5,15 +5,13 @@
 
 namespace lmc::units::velocity
 {
+using meters_per_second
+    = impl::cnt::unit_container<impl::def::definition_divide<
+        length::meters::definition,
+        time::seconds::definition>>;
+ADD_PREFIXES_TO_CONTAINER(meters_per_second)
 
-using dimension = impl::dim::dimensional_vector<
-    impl::dim::length<1>,
-    impl::dim::mass<0>,
-    impl::dim::time<-1>,
-    impl::dim::current<0>,
-    impl::dim::temperature<0>,
-    impl::dim::luminosity<0>,
-    impl::dim::substance<0>>;
+using dimension = meters_per_second::definition::dimension;
 
 template <impl::cnt::cpt::unit_container container>
 using is_velocity_unit
@@ -21,11 +19,6 @@ using is_velocity_unit
 
 template <impl::cnt::cpt::unit_container container>
 constexpr bool is_velocity_unit_v = is_velocity_unit<container>::value;
-
-using meters_per_second
-    = impl::cnt::unit_container<impl::def::definition_divide<
-        length::meters::definition,
-        time::seconds::definition>>;
 
 using kilometers_per_hour
     = impl::cnt::unit_container<impl::def::definition_divide<
@@ -45,7 +38,7 @@ using feet_per_second = impl::cnt::unit_container<impl::def::definition_divide<
     length::feet::definition,
     time::seconds::definition>>;
 
-using knot            = impl::cnt::unit_container<impl::def::definition_divide<
+using knots           = impl::cnt::unit_container<impl::def::definition_divide<
     length::nautical_miles::definition,
     time::hours::definition>>;
 

--- a/src/velocity.hh
+++ b/src/velocity.hh
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "length.hh"
+#include "time.hh"
+
+namespace lmc::units::velocity
+{
+
+using dimension = impl::dim::dimensional_vector<
+    impl::dim::length<1>,
+    impl::dim::mass<0>,
+    impl::dim::time<-1>,
+    impl::dim::current<0>,
+    impl::dim::temperature<0>,
+    impl::dim::luminosity<0>,
+    impl::dim::substance<0>>;
+
+template <impl::cnt::cpt::unit_container container>
+using is_velocity_unit
+    = dimension::equals<typename container::definition::dimension>;
+
+template <impl::cnt::cpt::unit_container container>
+constexpr bool is_velocity_unit_v = is_velocity_unit<container>::value;
+
+using meters_per_second           = impl::def::
+    definition_divide<length::meters::definition, time::seconds::definition>;
+
+using kilometers_per_hour = impl::def::
+    definition_divide<length::meters::definition, time::hours::definition>;
+
+using miles_per_hour = impl::def::
+    definition_divide<length::miles::definition, time::hours::definition>;
+
+using inches_per_second = impl::def::
+    definition_divide<length::inches::definition, time::seconds::definition>;
+
+using feet_per_second = impl::def::
+    definition_divide<length::feet::definition, time::seconds::definition>;
+
+using knot = impl::def::definition_divide<
+    length::nautical_miles::definition,
+    time::hours::definition>;
+
+} // namespace lmc::units::velocity
+

--- a/src/velocity.hh
+++ b/src/velocity.hh
@@ -22,24 +22,32 @@ using is_velocity_unit
 template <impl::cnt::cpt::unit_container container>
 constexpr bool is_velocity_unit_v = is_velocity_unit<container>::value;
 
-using meters_per_second           = impl::def::
-    definition_divide<length::meters::definition, time::seconds::definition>;
+using meters_per_second
+    = impl::cnt::unit_container<impl::def::definition_divide<
+        length::meters::definition,
+        time::seconds::definition>>;
 
-using kilometers_per_hour = impl::def::
-    definition_divide<length::meters::definition, time::hours::definition>;
+using kilometers_per_hour
+    = impl::cnt::unit_container<impl::def::definition_divide<
+        length::kilometers::definition,
+        time::hours::definition>>;
 
-using miles_per_hour = impl::def::
-    definition_divide<length::miles::definition, time::hours::definition>;
+using miles_per_hour = impl::cnt::unit_container<impl::def::definition_divide<
+    length::miles::definition,
+    time::hours::definition>>;
 
-using inches_per_second = impl::def::
-    definition_divide<length::inches::definition, time::seconds::definition>;
+using inches_per_second
+    = impl::cnt::unit_container<impl::def::definition_divide<
+        length::inches::definition,
+        time::seconds::definition>>;
 
-using feet_per_second = impl::def::
-    definition_divide<length::feet::definition, time::seconds::definition>;
+using feet_per_second = impl::cnt::unit_container<impl::def::definition_divide<
+    length::feet::definition,
+    time::seconds::definition>>;
 
-using knot = impl::def::definition_divide<
+using knot            = impl::cnt::unit_container<impl::def::definition_divide<
     length::nautical_miles::definition,
-    time::hours::definition>;
+    time::hours::definition>>;
 
 } // namespace lmc::units::velocity
 

--- a/src/voltage.hh
+++ b/src/voltage.hh
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "current.hh"
+#include "power.hh"
+
+namespace lmc::units::voltage
+{
+
+using dimension = impl::dim::dimensional_vector<
+    impl::dim::length<0>,
+    impl::dim::mass<0>,
+    impl::dim::time<1>,
+    impl::dim::current<1>,
+    impl::dim::temperature<0>,
+    impl::dim::luminosity<0>,
+    impl::dim::substance<0>>;
+
+template <impl::cnt::cpt::unit_container container>
+using is_voltage_unit
+    = dimension::equals<typename container::definition::dimension>;
+
+template <impl::cnt::cpt::unit_container container>
+constexpr bool is_voltage_unit_v = is_voltage_unit<container>::value;
+
+using volts = impl::cnt::unit_container<impl::def::definition_divide<
+    power::watts::definition,
+    current::amperes::definition>>;
+
+} // namespace lmc::units::voltage

--- a/src/voltage.hh
+++ b/src/voltage.hh
@@ -5,15 +5,12 @@
 
 namespace lmc::units::voltage
 {
+using volts = impl::cnt::unit_container<impl::def::definition_divide<
+    power::watts::definition,
+    current::amperes::definition>>;
+ADD_PREFIXES_TO_CONTAINER(volts)
 
-using dimension = impl::dim::dimensional_vector<
-    impl::dim::length<0>,
-    impl::dim::mass<0>,
-    impl::dim::time<1>,
-    impl::dim::current<1>,
-    impl::dim::temperature<0>,
-    impl::dim::luminosity<0>,
-    impl::dim::substance<0>>;
+using dimension = volts::definition::dimension;
 
 template <impl::cnt::cpt::unit_container container>
 using is_voltage_unit
@@ -21,9 +18,5 @@ using is_voltage_unit
 
 template <impl::cnt::cpt::unit_container container>
 constexpr bool is_voltage_unit_v = is_voltage_unit<container>::value;
-
-using volts = impl::cnt::unit_container<impl::def::definition_divide<
-    power::watts::definition,
-    current::amperes::definition>>;
 
 } // namespace lmc::units::voltage

--- a/testing/assert.hh
+++ b/testing/assert.hh
@@ -1,0 +1,244 @@
+#include "capacitance.hh"
+#include "catalytic_activity.hh"
+#include "charge.hh"
+#include "conductance.hh"
+#include "current.hh"
+#include "dimension.hh"
+#include "dose.hh"
+#include "energy.hh"
+#include "force.hh"
+#include "frequency.hh"
+#include "inductance.hh"
+#include "length.hh"
+#include "luminosity.hh"
+#include "magnetic_flux.hh"
+#include "magnetic_flux_density.hh"
+#include "mass.hh"
+#include "power.hh"
+#include "pressure.hh"
+#include "resistance.hh"
+#include "substance.hh"
+#include "temperature.hh"
+#include "time.hh"
+#include "voltage.hh"
+
+static_assert(lmc::units::impl::dim::dimensional_vector<
+              lmc::units::impl::dim::length<1>,
+              lmc::units::impl::dim::mass<0>,
+              lmc::units::impl::dim::time<0>,
+              lmc::units::impl::dim::current<0>,
+              lmc::units::impl::dim::temperature<0>,
+              lmc::units::impl::dim::luminosity<0>,
+              lmc::units::impl::dim::substance<0>>::
+                  equals_v<lmc::units::length::dimension>);
+
+static_assert(lmc::units::impl::dim::dimensional_vector<
+              lmc::units::impl::dim::length<0>,
+              lmc::units::impl::dim::mass<1>,
+              lmc::units::impl::dim::time<0>,
+              lmc::units::impl::dim::current<0>,
+              lmc::units::impl::dim::temperature<0>,
+              lmc::units::impl::dim::luminosity<0>,
+              lmc::units::impl::dim::substance<0>>::
+                  equals_v<lmc::units::mass::dimension>);
+
+static_assert(lmc::units::impl::dim::dimensional_vector<
+              lmc::units::impl::dim::length<0>,
+              lmc::units::impl::dim::mass<0>,
+              lmc::units::impl::dim::time<1>,
+              lmc::units::impl::dim::current<0>,
+              lmc::units::impl::dim::temperature<0>,
+              lmc::units::impl::dim::luminosity<0>,
+              lmc::units::impl::dim::substance<0>>::
+                  equals_v<lmc::units::time::dimension>);
+
+static_assert(lmc::units::impl::dim::dimensional_vector<
+              lmc::units::impl::dim::length<0>,
+              lmc::units::impl::dim::mass<0>,
+              lmc::units::impl::dim::time<0>,
+              lmc::units::impl::dim::current<1>,
+              lmc::units::impl::dim::temperature<0>,
+              lmc::units::impl::dim::luminosity<0>,
+              lmc::units::impl::dim::substance<0>>::
+                  equals_v<lmc::units::current::dimension>);
+
+static_assert(lmc::units::impl::dim::dimensional_vector<
+              lmc::units::impl::dim::length<0>,
+              lmc::units::impl::dim::mass<0>,
+              lmc::units::impl::dim::time<0>,
+              lmc::units::impl::dim::current<0>,
+              lmc::units::impl::dim::temperature<1>,
+              lmc::units::impl::dim::luminosity<0>,
+              lmc::units::impl::dim::substance<0>>::
+                  equals_v<lmc::units::temperature::dimension>);
+
+static_assert(lmc::units::impl::dim::dimensional_vector<
+              lmc::units::impl::dim::length<0>,
+              lmc::units::impl::dim::mass<0>,
+              lmc::units::impl::dim::time<0>,
+              lmc::units::impl::dim::current<0>,
+              lmc::units::impl::dim::temperature<0>,
+              lmc::units::impl::dim::luminosity<1>,
+              lmc::units::impl::dim::substance<0>>::
+                  equals_v<lmc::units::luminosity::dimension>);
+
+static_assert(lmc::units::impl::dim::dimensional_vector<
+              lmc::units::impl::dim::length<0>,
+              lmc::units::impl::dim::mass<0>,
+              lmc::units::impl::dim::time<0>,
+              lmc::units::impl::dim::current<0>,
+              lmc::units::impl::dim::temperature<0>,
+              lmc::units::impl::dim::luminosity<0>,
+              lmc::units::impl::dim::substance<1>>::
+                  equals_v<lmc::units::substance::dimension>);
+
+static_assert(lmc::units::impl::dim::dimensional_vector<
+              lmc::units::impl::dim::length<0>,
+              lmc::units::impl::dim::mass<0>,
+              lmc::units::impl::dim::time<-1>,
+              lmc::units::impl::dim::current<0>,
+              lmc::units::impl::dim::temperature<0>,
+              lmc::units::impl::dim::luminosity<0>,
+              lmc::units::impl::dim::substance<0>>::
+                  equals_v<lmc::units::frequency::dimension>);
+
+static_assert(lmc::units::impl::dim::dimensional_vector<
+              lmc::units::impl::dim::length<1>,
+              lmc::units::impl::dim::mass<1>,
+              lmc::units::impl::dim::time<-2>,
+              lmc::units::impl::dim::current<0>,
+              lmc::units::impl::dim::temperature<0>,
+              lmc::units::impl::dim::luminosity<0>,
+              lmc::units::impl::dim::substance<0>>::
+                  equals_v<lmc::units::force::dimension>);
+
+static_assert(lmc::units::impl::dim::dimensional_vector<
+              lmc::units::impl::dim::length<-1>,
+              lmc::units::impl::dim::mass<1>,
+              lmc::units::impl::dim::time<-2>,
+              lmc::units::impl::dim::current<0>,
+              lmc::units::impl::dim::temperature<0>,
+              lmc::units::impl::dim::luminosity<0>,
+              lmc::units::impl::dim::substance<0>>::
+                  equals_v<lmc::units::pressure::dimension>);
+
+static_assert(lmc::units::impl::dim::dimensional_vector<
+              lmc::units::impl::dim::length<2>,
+              lmc::units::impl::dim::mass<1>,
+              lmc::units::impl::dim::time<-2>,
+              lmc::units::impl::dim::current<0>,
+              lmc::units::impl::dim::temperature<0>,
+              lmc::units::impl::dim::luminosity<0>,
+              lmc::units::impl::dim::substance<0>>::
+                  equals_v<lmc::units::energy::dimension>);
+
+static_assert(lmc::units::impl::dim::dimensional_vector<
+              lmc::units::impl::dim::length<2>,
+              lmc::units::impl::dim::mass<1>,
+              lmc::units::impl::dim::time<-3>,
+              lmc::units::impl::dim::current<0>,
+              lmc::units::impl::dim::temperature<0>,
+              lmc::units::impl::dim::luminosity<0>,
+              lmc::units::impl::dim::substance<0>>::
+                  equals_v<lmc::units::power::dimension>);
+
+static_assert(lmc::units::impl::dim::dimensional_vector<
+              lmc::units::impl::dim::length<0>,
+              lmc::units::impl::dim::mass<0>,
+              lmc::units::impl::dim::time<1>,
+              lmc::units::impl::dim::current<1>,
+              lmc::units::impl::dim::temperature<0>,
+              lmc::units::impl::dim::luminosity<0>,
+              lmc::units::impl::dim::substance<0>>::
+                  equals_v<lmc::units::charge::dimension>);
+
+static_assert(lmc::units::impl::dim::dimensional_vector<
+              lmc::units::impl::dim::length<2>,
+              lmc::units::impl::dim::mass<1>,
+              lmc::units::impl::dim::time<-3>,
+              lmc::units::impl::dim::current<-1>,
+              lmc::units::impl::dim::temperature<0>,
+              lmc::units::impl::dim::luminosity<0>,
+              lmc::units::impl::dim::substance<0>>::
+                  equals_v<lmc::units::voltage::dimension>);
+
+static_assert(lmc::units::impl::dim::dimensional_vector<
+              lmc::units::impl::dim::length<-2>,
+              lmc::units::impl::dim::mass<-1>,
+              lmc::units::impl::dim::time<4>,
+              lmc::units::impl::dim::current<2>,
+              lmc::units::impl::dim::temperature<0>,
+              lmc::units::impl::dim::luminosity<0>,
+              lmc::units::impl::dim::substance<0>>::
+                  equals_v<lmc::units::capacitance::dimension>);
+
+static_assert(lmc::units::impl::dim::dimensional_vector<
+              lmc::units::impl::dim::length<2>,
+              lmc::units::impl::dim::mass<1>,
+              lmc::units::impl::dim::time<-3>,
+              lmc::units::impl::dim::current<-2>,
+              lmc::units::impl::dim::temperature<0>,
+              lmc::units::impl::dim::luminosity<0>,
+              lmc::units::impl::dim::substance<0>>::
+                  equals_v<lmc::units::resistance::dimension>);
+
+static_assert(lmc::units::impl::dim::dimensional_vector<
+              lmc::units::impl::dim::length<-2>,
+              lmc::units::impl::dim::mass<-1>,
+              lmc::units::impl::dim::time<3>,
+              lmc::units::impl::dim::current<2>,
+              lmc::units::impl::dim::temperature<0>,
+              lmc::units::impl::dim::luminosity<0>,
+              lmc::units::impl::dim::substance<0>>::
+                  equals_v<lmc::units::conductance::dimension>);
+
+static_assert(lmc::units::impl::dim::dimensional_vector<
+              lmc::units::impl::dim::length<2>,
+              lmc::units::impl::dim::mass<1>,
+              lmc::units::impl::dim::time<-2>,
+              lmc::units::impl::dim::current<-1>,
+              lmc::units::impl::dim::temperature<0>,
+              lmc::units::impl::dim::luminosity<0>,
+              lmc::units::impl::dim::substance<0>>::
+                  equals_v<lmc::units::magnetic_flux::dimension>);
+
+static_assert(lmc::units::impl::dim::dimensional_vector<
+              lmc::units::impl::dim::length<0>,
+              lmc::units::impl::dim::mass<1>,
+              lmc::units::impl::dim::time<-2>,
+              lmc::units::impl::dim::current<-1>,
+              lmc::units::impl::dim::temperature<0>,
+              lmc::units::impl::dim::luminosity<0>,
+              lmc::units::impl::dim::substance<0>>::
+                  equals_v<lmc::units::magnetic_flux_density::dimension>);
+
+static_assert(lmc::units::impl::dim::dimensional_vector<
+              lmc::units::impl::dim::length<2>,
+              lmc::units::impl::dim::mass<1>,
+              lmc::units::impl::dim::time<-2>,
+              lmc::units::impl::dim::current<-2>,
+              lmc::units::impl::dim::temperature<0>,
+              lmc::units::impl::dim::luminosity<0>,
+              lmc::units::impl::dim::substance<0>>::
+                  equals_v<lmc::units::inductance::dimension>);
+
+static_assert(lmc::units::impl::dim::dimensional_vector<
+              lmc::units::impl::dim::length<2>,
+              lmc::units::impl::dim::mass<0>,
+              lmc::units::impl::dim::time<-2>,
+              lmc::units::impl::dim::current<0>,
+              lmc::units::impl::dim::temperature<0>,
+              lmc::units::impl::dim::luminosity<0>,
+              lmc::units::impl::dim::substance<0>>::
+                  equals_v<lmc::units::dose::dimension>);
+
+static_assert(lmc::units::impl::dim::dimensional_vector<
+              lmc::units::impl::dim::length<0>,
+              lmc::units::impl::dim::mass<0>,
+              lmc::units::impl::dim::time<-1>,
+              lmc::units::impl::dim::current<0>,
+              lmc::units::impl::dim::temperature<0>,
+              lmc::units::impl::dim::luminosity<0>,
+              lmc::units::impl::dim::substance<1>>::
+                  equals_v<lmc::units::catalytic_activity::dimension>);
+

--- a/testing/main.cc
+++ b/testing/main.cc
@@ -1,21 +1,32 @@
-#include "temperature.hh"
+#include "length.hh"
+#include "time.hh"
+#include "unit_container.hh"
+#include "unit_definition.hh"
 
 #include <iostream>
 #include <ostream>
 
+constexpr lmc::units::length::kilometers m { 16.5 };
+constexpr lmc::units::time::hours        h { 1 };
+
+using kilometer_per_hour = lmc::units::impl::cnt::unit_container<
+    lmc::units::impl::def::definition_multiply<
+        lmc::units::length::kilometers::definition,
+        lmc::units::time::hours::definition>>;
+
+using meter_per_second = lmc::units::impl::cnt::unit_container<
+    lmc::units::impl::def::definition_multiply<
+        lmc::units::length::meters::definition,
+        lmc::units::time::seconds::definition>>;
+
+constexpr kilometer_per_hour kmps = m / h;
+constexpr meter_per_second   mps  = kmps;
+
+long double constexpr _m1_        = kmps.get_measurement();
+long double constexpr _m2_        = mps.get_measurement();
+
 auto
 main() -> int
 {
-    constexpr lmc::units::temperature::kilokelvins k { 1 };
-    constexpr lmc::units::temperature::celsius     c { k };
-    constexpr lmc::units::temperature::fahrenheit  f { c };
-
-    std::println(
-        std::cout,
-        "{}Kk = {}c = {}f",
-        k.get_measurement(),
-        c.get_measurement(),
-        f.get_measurement()
-    );
 }
 

--- a/testing/main.cc
+++ b/testing/main.cc
@@ -1,32 +1,24 @@
+#include "force.hh"
 #include "length.hh"
+#include "mass.hh"
 #include "time.hh"
 #include "unit_container.hh"
-#include "unit_definition.hh"
+#include "velocity.hh"
 
 #include <iostream>
 #include <ostream>
 
-constexpr lmc::units::length::kilometers m { 16.5 };
-constexpr lmc::units::time::hours        h { 1 };
-
-using kilometer_per_hour = lmc::units::impl::cnt::unit_container<
-    lmc::units::impl::def::definition_multiply<
-        lmc::units::length::kilometers::definition,
-        lmc::units::time::hours::definition>>;
-
-using meter_per_second = lmc::units::impl::cnt::unit_container<
-    lmc::units::impl::def::definition_multiply<
-        lmc::units::length::meters::definition,
-        lmc::units::time::seconds::definition>>;
-
-constexpr kilometer_per_hour kmps = m / h;
-constexpr meter_per_second   mps  = kmps;
-
-long double constexpr _m1_        = kmps.get_measurement();
-long double constexpr _m2_        = mps.get_measurement();
+lmc::units::force::dynes   p { 10 };
+lmc::units::force::newtons n = p;
 
 auto
 main() -> int
 {
+    std::println(
+        std::cout,
+        "{} dynes= {} newtons",
+        p.get_measurement(),
+        n.get_measurement()
+    );
 }
 

--- a/testing/main.cc
+++ b/testing/main.cc
@@ -1,3 +1,4 @@
+#include "acceleration.hh"
 #include "force.hh"
 #include "length.hh"
 #include "mass.hh"
@@ -8,17 +9,20 @@
 #include <iostream>
 #include <ostream>
 
-lmc::units::force::dynes   p { 10 };
-lmc::units::force::newtons n = p;
+constexpr lmc::units::acceleration::meters_per_second_squared g { 9.80665 };
+constexpr lmc::units::acceleration::feet_per_second_squared   f { g };
+
+long double constexpr x = f.get_measurement();
 
 auto
 main() -> int
 {
     std::println(
         std::cout,
-        "{} dynes= {} newtons",
-        p.get_measurement(),
-        n.get_measurement()
+        "{}kp = {}N = {}p",
+        kp.get_measurement(),
+        n.get_measurement(),
+        p.get_measurement()
     );
 }
 

--- a/testing/main.cc
+++ b/testing/main.cc
@@ -1,28 +1,23 @@
 #include "acceleration.hh"
-#include "force.hh"
-#include "length.hh"
-#include "mass.hh"
-#include "time.hh"
-#include "unit_container.hh"
-#include "velocity.hh"
 
 #include <iostream>
 #include <ostream>
 
-constexpr lmc::units::acceleration::meters_per_second_squared g { 9.80665 };
-constexpr lmc::units::acceleration::feet_per_second_squared   f { g };
-
-long double constexpr x = f.get_measurement();
+constexpr lmc::units::acceleration::meters_per_second_squared gravity {
+    9.80665L
+};
+constexpr lmc::units::acceleration::feet_per_second_squared gravity_fts {
+    gravity
+};
 
 auto
 main() -> int
 {
     std::println(
         std::cout,
-        "{}kp = {}N = {}p",
-        kp.get_measurement(),
-        n.get_measurement(),
-        p.get_measurement()
+        "g = {}m/s = {}ft/s",
+        gravity.get_measurement(),
+        gravity_fts.get_measurement()
     );
 }
 


### PR DESCRIPTION
This branch adds support for the use of compound units such as velocity, magnetic density and more.

- Unit Reciprocals
- Rearrangement of dimensional vectors
- Unit operators which produce compound types