### PR TITLE
[ADD] Unit literals for each type of unit

### DIFF
--- a/.mooncat.toml
+++ b/.mooncat.toml
@@ -1,6 +1,6 @@
 [project]
 name = "units"
-version = "0.3.3"
+version = "0.4.0"
 type = "library"
 
 [development]

--- a/include/acceleration
+++ b/include/acceleration
@@ -10,7 +10,7 @@ using meters_per_second_squared
     = impl::cnt::unit_container<impl::def::definition_divide<
         velocity::meters_per_second::definition,
         time::seconds::definition>>;
-ADD_PREFIXES_TO_CONTAINER(meters_per_second_squared)
+LMC_UNITS_ADD_PREFIXES_TO_CONTAINER(meters_per_second_squared)
 
 using dimension = meters_per_second_squared::definition::dimension;
 
@@ -31,3 +31,13 @@ using knots_per_second = impl::cnt::unit_container<impl::def::definition_divide<
     time::seconds::definition>>;
 
 } // namespace lmc::units::acceleration
+
+inline namespace ilmc
+{
+LMC_UNITS_CREATE_PREFIXED_UNIT_LITERAL_OPERATOR(
+    acceleration,
+    meters_per_second_squared
+)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(acceleration, feet_per_second_squared)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(acceleration, knots_per_second)
+} // namespace ilmc

--- a/include/angle
+++ b/include/angle
@@ -10,9 +10,9 @@ namespace lmc::units::angle
 constexpr std::intmax_t pi_num = 353981633974483;
 constexpr std::intmax_t pi_den = 2500000000000000;
 
-using pi_ratio  = std::ratio_add<std::ratio<3>, std::ratio<pi_num, pi_den>>;
+using pi_ratio = std::ratio_add<std::ratio<3>, std::ratio<pi_num, pi_den>>;
 
-using radians   = impl::cnt::unit_container<impl::def::definition_divide<
+using radians = impl::cnt::unit_container<impl::def::definition_divide<
     length::meters::definition,
     length::meters::definition>>;
 
@@ -24,3 +24,10 @@ using turns
 using degrees = impl::abbr::derive<std::ratio<1, 360>, turns>;
 
 } // namespace lmc::units::angle
+
+inline namespace ilmc
+{
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(angle, radians)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(angle, turns)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(angle, degrees)
+} // namespace ilmc

--- a/include/capacitance
+++ b/include/capacitance
@@ -10,7 +10,7 @@ namespace lmc::units::capacitance
 using farads = impl::cnt::unit_container<impl::def::definition_divide<
     charge::coulombs::definition,
     voltage::volts::definition>>;
-ADD_PREFIXES_TO_CONTAINER(farads)
+LMC_UNITS_ADD_PREFIXES_TO_CONTAINER(farads)
 
 using dimension = farads::definition::dimension;
 
@@ -22,3 +22,9 @@ template <impl::cnt::cpt::unit_container container>
 constexpr bool is_capacitance_unit_v = is_capacitance_unit<container>::value;
 
 } // namespace lmc::units::capacitance
+
+inline namespace ilmc
+{
+LMC_UNITS_CREATE_PREFIXED_UNIT_LITERAL_OPERATOR(capacitance, farads)
+} // namespace ilmc
+

--- a/include/catalytic_activity
+++ b/include/catalytic_activity
@@ -10,7 +10,7 @@ namespace lmc::units::catalytic_activity
 using katals = impl::cnt::unit_container<impl::def::definition_divide<
     substance::moles::definition,
     time::seconds::definition>>;
-ADD_PREFIXES_TO_CONTAINER(katals)
+LMC_UNITS_ADD_PREFIXES_TO_CONTAINER(katals)
 
 using dimension = katals::definition::dimension;
 
@@ -23,3 +23,8 @@ constexpr bool is_catalytic_activity_unit_v
     = is_catalytic_activity_unit<container>::value;
 
 } // namespace lmc::units::catalytic_activity
+
+inline namespace ilmc
+{
+LMC_UNITS_CREATE_PREFIXED_UNIT_LITERAL_OPERATOR(catalytic_activity, katals)
+} // namespace ilmc

--- a/include/charge
+++ b/include/charge
@@ -10,7 +10,7 @@ namespace lmc::units::charge
 using coulombs = impl::cnt::unit_container<impl::def::definition_multiply<
     current::amperes::definition,
     time::seconds::definition>>;
-ADD_PREFIXES_TO_CONTAINER(coulombs)
+LMC_UNITS_ADD_PREFIXES_TO_CONTAINER(coulombs)
 
 using dimension = coulombs::definition::dimension;
 
@@ -22,3 +22,8 @@ template <impl::cnt::cpt::unit_container container>
 constexpr bool is_charge_unit_v = is_charge_unit<container>::value;
 
 } // namespace lmc::units::charge
+
+inline namespace ilmc
+{
+LMC_UNITS_CREATE_PREFIXED_UNIT_LITERAL_OPERATOR(charge, coulombs)
+} // namespace ilmc

--- a/include/conductance
+++ b/include/conductance
@@ -8,7 +8,7 @@ namespace lmc::units::conductance
 {
 using siemens = impl::cnt::unit_container<
     impl::def::definition_reciprocate<resistance::ohms::definition>>;
-ADD_PREFIXES_TO_CONTAINER(siemens)
+LMC_UNITS_ADD_PREFIXES_TO_CONTAINER(siemens)
 
 using dimension = siemens::definition::dimension;
 
@@ -20,3 +20,8 @@ template <impl::cnt::cpt::unit_container container>
 constexpr bool is_conductance_unit_v = is_conductance_unit<container>::value;
 
 } // namespace lmc::units::conductance
+
+inline namespace ilmc
+{
+LMC_UNITS_CREATE_PREFIXED_UNIT_LITERAL_OPERATOR(conductance, siemens)
+} // namespace ilmc

--- a/include/current
+++ b/include/current
@@ -30,6 +30,11 @@ using amperes = impl::cnt::unit_container<impl::def::unit_definition<
     impl::cmp::base_unit_ratio,
     impl::cmp::base_unit_delta>>;
 
-ADD_PREFIXES_TO_CONTAINER(amperes)
+LMC_UNITS_ADD_PREFIXES_TO_CONTAINER(amperes)
 
 } // namespace lmc::units::current
+
+inline namespace ilmc
+{
+LMC_UNITS_CREATE_PREFIXED_UNIT_LITERAL_OPERATOR(current, amperes)
+} // namespace ilmc

--- a/include/dose
+++ b/include/dose
@@ -12,7 +12,7 @@ namespace absorbed
 using grays = impl::cnt::unit_container<impl::def::definition_divide<
     energy::joules::definition,
     mass::kilograms::definition>>;
-ADD_PREFIXES_TO_CONTAINER(grays)
+LMC_UNITS_ADD_PREFIXES_TO_CONTAINER(grays)
 
 } // namespace absorbed
 
@@ -21,7 +21,7 @@ namespace equivalent
 using sieverts = impl::cnt::unit_container<impl::def::definition_divide<
     energy::joules::definition,
     mass::kilograms::definition>>;
-ADD_PREFIXES_TO_CONTAINER(sieverts)
+LMC_UNITS_ADD_PREFIXES_TO_CONTAINER(sieverts)
 
 } // namespace equivalent
 
@@ -38,3 +38,10 @@ template <impl::cnt::cpt::unit_container container>
 constexpr bool is_dose_unit_v = is_dose_unit<container>::value;
 
 } // namespace lmc::units::dose
+  //
+
+inline namespace ilmc
+{
+LMC_UNITS_CREATE_PREFIXED_UNIT_LITERAL_OPERATOR(dose::absorbed, grays)
+LMC_UNITS_CREATE_PREFIXED_UNIT_LITERAL_OPERATOR(dose::equivalent, sieverts)
+} // namespace ilmc

--- a/include/energy
+++ b/include/energy
@@ -9,7 +9,7 @@ namespace lmc::units::energy
 using joules = impl::cnt::unit_container<impl::def::definition_multiply<
     force::newtons::definition,
     length::meters::definition>>;
-ADD_PREFIXES_TO_CONTAINER(joules)
+LMC_UNITS_ADD_PREFIXES_TO_CONTAINER(joules)
 
 using dimension = joules::definition::dimension;
 
@@ -20,7 +20,7 @@ using is_energy_unit
 template <impl::cnt::cpt::unit_container container>
 constexpr bool is_energy_unit_v = is_energy_unit<container>::value;
 
-using foot_pound_force          = impl::abbr::
+using foot_pound_force = impl::abbr::
     derive<std::ratio_add<std::ratio<1>, std::ratio<1779, 5000>>, joules>;
 
 using horsepower_hour = impl::abbr::
@@ -42,3 +42,14 @@ using electronvolts
 using ton_of_tnt = impl::abbr::derive<std::ratio<4184>, joules>;
 
 } // namespace lmc::units::energy
+
+inline namespace ilmc
+{
+LMC_UNITS_CREATE_PREFIXED_UNIT_LITERAL_OPERATOR(energy, joules)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(energy, foot_pound_force)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(energy, horsepower_hour)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(energy, kilowatt_hour)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(energy, calories_it)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(energy, electronvolts)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(energy, ton_of_tnt)
+} // namespace ilmc

--- a/include/force
+++ b/include/force
@@ -13,7 +13,7 @@ using newtons = impl::cnt::unit_container<impl::def::definition_divide<
         mass::kilograms::definition,
         length::meters::definition>,
     impl::def::definition_squared<time::seconds::definition>>>;
-ADD_PREFIXES_TO_CONTAINER(newtons)
+LMC_UNITS_ADD_PREFIXES_TO_CONTAINER(newtons)
 
 using dimension = newtons::definition::dimension;
 
@@ -24,7 +24,7 @@ using is_force_unit
 template <impl::cnt::cpt::unit_container container>
 constexpr bool is_force_unit_v = is_force_unit<container>::value;
 
-using kilopond                 = impl::abbr::
+using kilopond = impl::abbr::
     derive<std::ratio_add<std::ratio<9>, std::ratio<16133, 20000>>, newtons>;
 
 using pounds = impl::abbr::
@@ -36,3 +36,8 @@ using poundal
 using dynes = impl::abbr::derive<std::ratio<1, 100000>, newtons>;
 
 } // namespace lmc::units::force
+
+inline namespace ilmc
+{
+LMC_UNITS_CREATE_PREFIXED_UNIT_LITERAL_OPERATOR(force, newtons)
+} // namespace ilmc

--- a/include/frequency
+++ b/include/frequency
@@ -8,7 +8,7 @@ namespace lmc::units::frequency
 {
 using hertz = impl::cnt::unit_container<
     impl::def::definition_reciprocate<time::seconds::definition>>;
-ADD_PREFIXES_TO_CONTAINER(hertz)
+LMC_UNITS_ADD_PREFIXES_TO_CONTAINER(hertz)
 
 using dimension = hertz::definition::dimension;
 
@@ -20,3 +20,9 @@ template <impl::cnt::cpt::unit_container container>
 constexpr bool is_frequency_unit_v = is_frequency_unit<container>::value;
 
 } // namespace lmc::units::frequency
+  //
+
+inline namespace ilmc
+{
+LMC_UNITS_CREATE_PREFIXED_UNIT_LITERAL_OPERATOR(frequency, hertz)
+} // namespace ilmc

--- a/include/illuminance
+++ b/include/illuminance
@@ -7,10 +7,16 @@
 namespace lmc::units::illuminance
 {
 
-using luxes     = impl::cnt::unit_container<impl::def::definition_divide<
+using luxes = impl::cnt::unit_container<impl::def::definition_divide<
     luminous_flux::lumens::definition,
     impl::def::definition_squared<length::meters::definition>>>;
+LMC_UNITS_ADD_PREFIXES_TO_CONTAINER(luxes)
 
 using dimension = luxes::definition::dimension;
 
 } // namespace lmc::units::illuminance
+
+inline namespace ilmc
+{
+LMC_UNITS_CREATE_PREFIXED_UNIT_LITERAL_OPERATOR(illuminance, luxes)
+} // namespace ilmc

--- a/include/impl/prefixes
+++ b/include/impl/prefixes
@@ -27,7 +27,7 @@ using peta  = impl::cmp::unit_prefix<std::peta>;
 using exa   = impl::cmp::unit_prefix<std::exa>;
 } // namespace lmc::units::prefix
 
-#define ADD_PREFIXES_TO_CONTAINER(name)                                        \
+#define LMC_UNITS_ADD_PREFIXES_TO_CONTAINER(name)                              \
     using atto##name = impl::cnt::                                             \
         container_with_different_prefix<name, lmc::units::prefix::atto>;       \
     using femto##name = impl::cnt::                                            \
@@ -60,4 +60,22 @@ using exa   = impl::cmp::unit_prefix<std::exa>;
         container_with_different_prefix<name, lmc::units::prefix::peta>;       \
     using exa##name = impl::cnt::                                              \
         container_with_different_prefix<name, lmc::units::prefix::exa>;
+
+#define LMC_UNITS_CREATE_PREFIXED_UNIT_LITERAL_OPERATOR(dimension, name)       \
+    LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(dimension, atto##name)              \
+    LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(dimension, femto##name)             \
+    LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(dimension, pico##name)              \
+    LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(dimension, nano##name)              \
+    LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(dimension, micro##name)             \
+    LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(dimension, milli##name)             \
+    LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(dimension, centi##name)             \
+    LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(dimension, deci##name)              \
+    LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(dimension, deca##name)              \
+    LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(dimension, hecto##name)             \
+    LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(dimension, kilo##name)              \
+    LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(dimension, mega##name)              \
+    LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(dimension, giga##name)              \
+    LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(dimension, tera##name)              \
+    LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(dimension, peta##name)              \
+    LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(dimension, exa##name)
 

--- a/include/impl/unit_container
+++ b/include/impl/unit_container
@@ -150,3 +150,18 @@ template <util::cpt::ratio r, cnt::cpt::unit_container t>
 using derive = impl::cnt::container_with_derived_ratio<r, t>;
 } // namespace lmc::units::impl::abbr
 
+#define LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(dimension, name)                \
+    [[nodiscard]]                                                              \
+    constexpr auto                                                             \
+    operator""_##name (long double value) -> lmc::units::dimension::name       \
+    {                                                                          \
+        return lmc::units::dimension::name { value };                          \
+    }                                                                          \
+    [[nodiscard]]                                                              \
+    constexpr auto                                                             \
+    operator""_##name (unsigned long long value)                               \
+        -> lmc::units::dimension::name                                         \
+    {                                                                          \
+        return lmc::units::dimension::name { static_cast<long double>(value    \
+        ) };                                                                   \
+    }

--- a/include/inductance
+++ b/include/inductance
@@ -9,7 +9,7 @@ namespace lmc::units::inductance
 using henrys = impl::cnt::unit_container<impl::def::definition_divide<
     magnetic_flux::webers::definition,
     current::amperes::definition>>;
-ADD_PREFIXES_TO_CONTAINER(henrys)
+LMC_UNITS_ADD_PREFIXES_TO_CONTAINER(henrys)
 
 using dimension = henrys::definition::dimension;
 
@@ -21,3 +21,9 @@ template <impl::cnt::cpt::unit_container container>
 constexpr bool is_inductance_unit_v = is_inductance_unit<container>::value;
 
 } // namespace lmc::units::inductance
+  //
+
+inline namespace ilmc
+{
+LMC_UNITS_CREATE_PREFIXED_UNIT_LITERAL_OPERATOR(inductance, henrys)
+} // namespace ilmc

--- a/include/length
+++ b/include/length
@@ -1,7 +1,5 @@
 // vim: set ft=cpp:
 
-// vim: set ft=cpp:
-
 #pragma once
 
 #include <mooncat/units/impl/prefixes>
@@ -26,7 +24,7 @@ using is_length_unit
 template <impl::cnt::cpt::unit_container container>
 constexpr bool is_length_unit_v = is_length_unit<container>::value;
 
-using meters         = impl::cnt::unit_container<impl::def::unit_definition<
+using meters = impl::cnt::unit_container<impl::def::unit_definition<
     dimension,
     impl::cmp::base_unit_prefix,
     impl::cmp::base_unit_ratio,
@@ -49,6 +47,28 @@ using nautical_miles = impl::abbr::derive<std::ratio<10>, cables>;
 using links          = impl::abbr::derive<std::ratio<66, 100>, feet>;
 using rods           = impl::abbr::derive<std::ratio<25>, links>;
 
-ADD_PREFIXES_TO_CONTAINER(meters)
+LMC_UNITS_ADD_PREFIXES_TO_CONTAINER(meters)
 
 } // namespace lmc::units::length
+
+inline namespace ilmc
+{
+LMC_UNITS_CREATE_PREFIXED_UNIT_LITERAL_OPERATOR(length, meters)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(length, feet)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(length, twips)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(length, thous)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(length, barleycorns)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(length, inches)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(length, hands)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(length, yards)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(length, chains)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(length, furlongs)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(length, miles)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(length, leagues)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(length, fathoms)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(length, cables)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(length, nautical_miles)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(length, links)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(length, rods)
+} // namespace ilmc
+

--- a/include/luminosity
+++ b/include/luminosity
@@ -30,6 +30,12 @@ using candelas = impl::cnt::unit_container<impl::def::unit_definition<
     impl::cmp::base_unit_ratio,
     impl::cmp::base_unit_delta>>;
 
-ADD_PREFIXES_TO_CONTAINER(candelas)
+LMC_UNITS_ADD_PREFIXES_TO_CONTAINER(candelas)
 
 } // namespace lmc::units::luminosity
+  //
+
+inline namespace ilmc
+{
+LMC_UNITS_CREATE_PREFIXED_UNIT_LITERAL_OPERATOR(luminosity, candelas)
+} // namespace ilmc

--- a/include/luminous_flux
+++ b/include/luminous_flux
@@ -8,10 +8,16 @@
 namespace lmc::units::luminous_flux
 {
 
-using lumens    = impl::cnt::unit_container<impl::def::definition_multiply<
+using lumens = impl::cnt::unit_container<impl::def::definition_multiply<
     luminosity::candelas::definition,
     solid_angle::steradians::definition>>;
+LMC_UNITS_ADD_PREFIXES_TO_CONTAINER(lumens)
 
 using dimension = lumens::definition::dimension;
 
 } // namespace lmc::units::luminous_flux
+
+inline namespace ilmc
+{
+LMC_UNITS_CREATE_PREFIXED_UNIT_LITERAL_OPERATOR(luminous_flux, lumens)
+} // namespace ilmc

--- a/include/magnetic_flux
+++ b/include/magnetic_flux
@@ -10,7 +10,7 @@ namespace lmc::units::magnetic_flux
 using webers = impl::cnt::unit_container<impl::def::definition_multiply<
     voltage::volts::definition,
     time::seconds::definition>>;
-ADD_PREFIXES_TO_CONTAINER(webers)
+LMC_UNITS_ADD_PREFIXES_TO_CONTAINER(webers)
 
 using dimension = webers::definition::dimension;
 
@@ -23,3 +23,8 @@ constexpr bool is_magnetic_flux_unit_v
     = is_magnetic_flux_unit<container>::value;
 
 } // namespace lmc::units::magnetic_flux
+
+inline namespace ilmc
+{
+LMC_UNITS_CREATE_PREFIXED_UNIT_LITERAL_OPERATOR(magnetic_flux, webers)
+} // namespace ilmc

--- a/include/magnetic_flux_density
+++ b/include/magnetic_flux_density
@@ -9,7 +9,7 @@ namespace lmc::units::magnetic_flux_density
 using teslas = impl::cnt::unit_container<impl::def::definition_divide<
     magnetic_flux::webers::definition,
     impl::def::definition_squared<length::meters::definition>>>;
-ADD_PREFIXES_TO_CONTAINER(teslas)
+LMC_UNITS_ADD_PREFIXES_TO_CONTAINER(teslas)
 
 using dimension = teslas::definition::dimension;
 
@@ -22,3 +22,8 @@ constexpr bool is_magnetic_flux_density_unit_v
     = is_magnetic_flux_density_unit<container>::value;
 
 } // namespace lmc::units::magnetic_flux_density
+
+inline namespace ilmc
+{
+LMC_UNITS_CREATE_PREFIXED_UNIT_LITERAL_OPERATOR(magnetic_flux_density, teslas)
+} // namespace ilmc

--- a/include/mass
+++ b/include/mass
@@ -24,7 +24,7 @@ using is_mass_unit
 template <impl::cnt::cpt::unit_container container>
 constexpr bool is_mass_unit_v = is_mass_unit<container>::value;
 
-using grams          = impl::cnt::unit_container<impl::def::unit_definition<
+using grams = impl::cnt::unit_container<impl::def::unit_definition<
     dimension,
     impl::cmp::base_unit_prefix,
     impl::cmp::base_unit_ratio,
@@ -39,6 +39,19 @@ using quarters       = impl::abbr::derive<std::ratio<28>, pounds>;
 using hundredweights = impl::abbr::derive<std::ratio<112>, pounds>;
 using tons           = impl::abbr::derive<std::ratio<2240>, pounds>;
 
-ADD_PREFIXES_TO_CONTAINER(grams)
+LMC_UNITS_ADD_PREFIXES_TO_CONTAINER(grams)
 
 } // namespace lmc::units::mass
+
+inline namespace ilmc
+{
+LMC_UNITS_CREATE_PREFIXED_UNIT_LITERAL_OPERATOR(mass, grams)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(mass, pounds)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(mass, grains)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(mass, drachms)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(mass, ounces)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(mass, stones)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(mass, quarters)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(mass, hundredweights)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(mass, tons)
+} // namespace ilmc

--- a/include/power
+++ b/include/power
@@ -9,7 +9,7 @@ namespace lmc::units::power
 using watts = impl::cnt::unit_container<impl::def::definition_divide<
     energy::joules::definition,
     time::seconds::definition>>;
-ADD_PREFIXES_TO_CONTAINER(watts)
+LMC_UNITS_ADD_PREFIXES_TO_CONTAINER(watts)
 
 using dimension = watts::definition::dimension;
 
@@ -23,3 +23,8 @@ constexpr bool is_power_unit_v = is_power_unit<container>::value;
 using horsepower = impl::abbr::derive<std::ratio<7457, 10>, watts>;
 
 } // namespace lmc::units::power
+
+inline namespace ilmc
+{
+LMC_UNITS_CREATE_PREFIXED_UNIT_LITERAL_OPERATOR(power, watts)
+} // namespace ilmc

--- a/include/pressure
+++ b/include/pressure
@@ -9,7 +9,7 @@ namespace lmc::units::pressure
 using pascals = impl::cnt::unit_container<impl::def::definition_divide<
     force::newtons::definition,
     impl::def::definition_squared<length::meters::definition>>>;
-ADD_PREFIXES_TO_CONTAINER(pascals)
+LMC_UNITS_ADD_PREFIXES_TO_CONTAINER(pascals)
 
 using dimension = pascals::definition::dimension;
 
@@ -27,10 +27,20 @@ using technical_atmospheres
 
 using atmospheres = impl::abbr::derive<std::ratio<101325>, pascals>;
 
-using torrs       = impl::abbr::derive<std::ratio<1, 760>, atmospheres>;
+using torrs = impl::abbr::derive<std::ratio<1, 760>, atmospheres>;
 
 using pounds_per_square_inch = impl::abbr::derive<
     std::ratio_add<std::ratio<6894>, std::ratio<47330823, 62500000>>,
     pascals>;
 
 } // namespace lmc::units::pressure
+
+inline namespace ilmc
+{
+LMC_UNITS_CREATE_PREFIXED_UNIT_LITERAL_OPERATOR(pressure, pascals)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(pressure, bars)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(pressure, technical_atmospheres)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(pressure, atmospheres)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(pressure, torrs)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(pressure, pounds_per_square_inch)
+} // namespace ilmc

--- a/include/resistance
+++ b/include/resistance
@@ -10,7 +10,7 @@ namespace lmc::units::resistance
 using ohms = impl::cnt::unit_container<impl::def::definition_divide<
     voltage::volts::definition,
     current::amperes::definition>>;
-ADD_PREFIXES_TO_CONTAINER(ohms)
+LMC_UNITS_ADD_PREFIXES_TO_CONTAINER(ohms)
 
 using dimension = ohms::definition::dimension;
 
@@ -22,3 +22,9 @@ template <impl::cnt::cpt::unit_container container>
 constexpr bool is_resistance_unit_v = is_resistance_unit<container>::value;
 
 } // namespace lmc::units::resistance
+
+inline namespace ilmc
+{
+LMC_UNITS_CREATE_PREFIXED_UNIT_LITERAL_OPERATOR(resistance, ohms)
+} // namespace ilmc
+

--- a/include/solid_angle
+++ b/include/solid_angle
@@ -13,3 +13,9 @@ using steradians = impl::cnt::unit_container<
 using dimension = steradians::definition::dimension;
 
 } // namespace lmc::units::solid_angle
+
+inline namespace ilmc
+{
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(solid_angle, steradians)
+} // namespace ilmc
+

--- a/include/substance
+++ b/include/substance
@@ -30,6 +30,11 @@ using moles = impl::cnt::unit_container<impl::def::unit_definition<
     impl::cmp::base_unit_ratio,
     impl::cmp::base_unit_delta>>;
 
-ADD_PREFIXES_TO_CONTAINER(moles)
+LMC_UNITS_ADD_PREFIXES_TO_CONTAINER(moles)
 
 } // namespace lmc::units::substance
+
+inline namespace ilmc
+{
+LMC_UNITS_CREATE_PREFIXED_UNIT_LITERAL_OPERATOR(substance, moles)
+} // namespace ilmc

--- a/include/temperature
+++ b/include/temperature
@@ -24,13 +24,13 @@ using is_temperature_unit
 template <impl::cnt::cpt::unit_container container>
 constexpr bool is_temperature_unit_v = is_temperature_unit<container>::value;
 
-using kelvins    = impl::cnt::unit_container<impl::def::unit_definition<
+using kelvins = impl::cnt::unit_container<impl::def::unit_definition<
     dimension,
     impl::cmp::base_unit_prefix,
     impl::cmp::base_unit_ratio,
     impl::cmp::base_unit_delta>>;
 
-using celsius    = impl::cnt::unit_container<impl::def::unit_definition<
+using celsius = impl::cnt::unit_container<impl::def::unit_definition<
     dimension,
     impl::cmp::base_unit_prefix,
     impl::def::derive_unit_ratio<std::ratio<1>, kelvins::definition>,
@@ -42,6 +42,11 @@ using fahrenheit = impl::cnt::unit_container<impl::def::unit_definition<
     impl::def::derive_unit_ratio<std::ratio<5, 9>, celsius::definition>,
     impl::def::derive_unit_delta<celsius::definition, std::ratio<160, 9>>>>;
 
-ADD_PREFIXES_TO_CONTAINER(kelvins)
+LMC_UNITS_ADD_PREFIXES_TO_CONTAINER(kelvins)
 
 } // namespace lmc::units::temperature
+
+inline namespace ilmc
+{
+LMC_UNITS_CREATE_PREFIXED_UNIT_LITERAL_OPERATOR(temperature, kelvins)
+} // namespace ilmc

--- a/include/time
+++ b/include/time
@@ -24,7 +24,7 @@ using is_time_unit
 template <impl::cnt::cpt::unit_container container>
 constexpr bool is_time_unit_v = is_time_unit<container>::value;
 
-using seconds    = impl::cnt::unit_container<impl::def::unit_definition<
+using seconds = impl::cnt::unit_container<impl::def::unit_definition<
     dimension,
     impl::cmp::base_unit_prefix,
     impl::cmp::base_unit_ratio,
@@ -44,6 +44,16 @@ using decades    = impl::abbr::derive<std::ratio<10>, years>;
 using centuries  = impl::abbr::derive<std::ratio<100>, years>;
 using eons       = impl::abbr::derive<std::ratio<1000000000>, years>;
 
-ADD_PREFIXES_TO_CONTAINER(seconds)
+LMC_UNITS_ADD_PREFIXES_TO_CONTAINER(seconds)
 
 } // namespace lmc::units::time
+
+inline namespace ilmc
+{
+LMC_UNITS_CREATE_PREFIXED_UNIT_LITERAL_OPERATOR(time, seconds)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(time, minutes)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(time, hours)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(time, days)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(time, weeks)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(time, years)
+} // namespace ilmc

--- a/include/velocity
+++ b/include/velocity
@@ -11,7 +11,7 @@ using meters_per_second
     = impl::cnt::unit_container<impl::def::definition_divide<
         length::meters::definition,
         time::seconds::definition>>;
-ADD_PREFIXES_TO_CONTAINER(meters_per_second)
+LMC_UNITS_ADD_PREFIXES_TO_CONTAINER(meters_per_second)
 
 using dimension = meters_per_second::definition::dimension;
 
@@ -22,10 +22,10 @@ using is_velocity_unit
 template <impl::cnt::cpt::unit_container container>
 constexpr bool is_velocity_unit_v = is_velocity_unit<container>::value;
 
-using kilometers_per_hour
-    = impl::cnt::unit_container<impl::def::definition_divide<
-        length::kilometers::definition,
-        time::hours::definition>>;
+using meters_per_hour = impl::cnt::unit_container<impl::def::definition_divide<
+    length::kilometers::definition,
+    time::hours::definition>>;
+LMC_UNITS_ADD_PREFIXES_TO_CONTAINER(meters_per_hour)
 
 using miles_per_hour = impl::cnt::unit_container<impl::def::definition_divide<
     length::miles::definition,
@@ -40,8 +40,19 @@ using feet_per_second = impl::cnt::unit_container<impl::def::definition_divide<
     length::feet::definition,
     time::seconds::definition>>;
 
-using knots           = impl::cnt::unit_container<impl::def::definition_divide<
+using knots = impl::cnt::unit_container<impl::def::definition_divide<
     length::nautical_miles::definition,
     time::hours::definition>>;
 
 } // namespace lmc::units::velocity
+
+inline namespace ilmc
+{
+LMC_UNITS_CREATE_PREFIXED_UNIT_LITERAL_OPERATOR(velocity, meters_per_second)
+LMC_UNITS_CREATE_PREFIXED_UNIT_LITERAL_OPERATOR(velocity, meters_per_hour)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(velocity, miles_per_hour)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(velocity, inches_per_second)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(velocity, feet_per_second)
+LMC_UNITS_CREATE_UNIT_LITERAL_OPERATOR(velocity, knots)
+} // namespace ilmc
+

--- a/include/voltage
+++ b/include/voltage
@@ -10,7 +10,7 @@ namespace lmc::units::voltage
 using volts = impl::cnt::unit_container<impl::def::definition_divide<
     power::watts::definition,
     current::amperes::definition>>;
-ADD_PREFIXES_TO_CONTAINER(volts)
+LMC_UNITS_ADD_PREFIXES_TO_CONTAINER(volts)
 
 using dimension = volts::definition::dimension;
 
@@ -22,3 +22,8 @@ template <impl::cnt::cpt::unit_container container>
 constexpr bool is_voltage_unit_v = is_voltage_unit<container>::value;
 
 } // namespace lmc::units::voltage
+
+inline namespace ilmc
+{
+LMC_UNITS_CREATE_PREFIXED_UNIT_LITERAL_OPERATOR(voltage, volts)
+} // namespace ilmc

--- a/testing/assert.hh
+++ b/testing/assert.hh
@@ -1,3 +1,4 @@
+#include <mooncat/units/acceleration>
 #include <mooncat/units/angle>
 #include <mooncat/units/capacitance>
 #include <mooncat/units/catalytic_activity>
@@ -24,6 +25,7 @@
 #include <mooncat/units/substance>
 #include <mooncat/units/temperature>
 #include <mooncat/units/time>
+#include <mooncat/units/velocity>
 #include <mooncat/units/voltage>
 
 static_assert(lmc::units::impl::dim::dimensional_vector<
@@ -95,6 +97,26 @@ static_assert(lmc::units::impl::dim::dimensional_vector<
               lmc::units::impl::dim::luminosity<0>,
               lmc::units::impl::dim::substance<1>>::
                   equals_v<lmc::units::substance::dimension>);
+
+static_assert(lmc::units::impl::dim::dimensional_vector<
+              lmc::units::impl::dim::length<1>,
+              lmc::units::impl::dim::mass<0>,
+              lmc::units::impl::dim::time<-1>,
+              lmc::units::impl::dim::current<0>,
+              lmc::units::impl::dim::temperature<0>,
+              lmc::units::impl::dim::luminosity<0>,
+              lmc::units::impl::dim::substance<0>>::
+                  equals_v<lmc::units::velocity::dimension>);
+
+static_assert(lmc::units::impl::dim::dimensional_vector<
+              lmc::units::impl::dim::length<1>,
+              lmc::units::impl::dim::mass<0>,
+              lmc::units::impl::dim::time<-2>,
+              lmc::units::impl::dim::current<0>,
+              lmc::units::impl::dim::temperature<0>,
+              lmc::units::impl::dim::luminosity<0>,
+              lmc::units::impl::dim::substance<0>>::
+                  equals_v<lmc::units::acceleration::dimension>);
 
 static_assert(lmc::units::impl::dim::dimensional_vector<
               lmc::units::impl::dim::length<0>,
@@ -285,3 +307,4 @@ static_assert(lmc::units::impl::dim::dimensional_vector<
               lmc::units::impl::dim::luminosity<1>,
               lmc::units::impl::dim::substance<0>>::
                   equals_v<lmc::units::illuminance::dimension>);
+


### PR DESCRIPTION
Creates unit literals for units; Just practicality.
There are no unit abbreviations in order to prevent conflicts between units such as with `nanometers` and `nautical_miles`.

An example would be:
```cpp

#include <mooncat/units/length>
auto length = 10_meters;
```